### PR TITLE
issue 1719 custom error payloads for the api-key policy 3/3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-api</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - API</name>
 

--- a/src/main/java/io/gravitee/policy/api/PolicyResult.java
+++ b/src/main/java/io/gravitee/policy/api/PolicyResult.java
@@ -57,7 +57,7 @@ public interface PolicyResult {
     }
 
     static PolicyResult build(boolean isFailure, int statusCode, String message) {
-        return build(isFailure, statusCode, message, MediaType.TEXT_PLAIN);
+        return build(isFailure, statusCode, message, null);
     }
 
     static PolicyResult failure(int statusCode, String message) {


### PR DESCRIPTION
To enable custom error payloads for the API-key policy as describted in gravitee-io/issues/issues/1719 three changes (PR's) arre needed:

1: https://github.com/gravitee-io/gravitee-policy-apikey/pull/20
Adds a configuration to the API key policy to enable custom responses.

2: https://github.com/gravitee-io/gravitee-gateway/pull/388
Is needed to enable payloads different than JSON and to answer with the configured response even if no API key is send.

**3. this PR**
This PR changes the default content type of a PolicyResult to null. Together with PR 2 ... this change enables creating PolicyResults with custom payloads other than JSON.