### PR TITLE
feat: Add fail method with key and contentType for oauth2 policy

### DIFF
--- a/src/main/java/io/gravitee/policy/api/PolicyResult.java
+++ b/src/main/java/io/gravitee/policy/api/PolicyResult.java
@@ -92,4 +92,8 @@ public interface PolicyResult {
     static PolicyResult failure(int statusCode, String message, String contentType) {
         return build(statusCode, null, message, null, contentType);
     }
+
+    static PolicyResult failure(String key, int statusCode, String message, String contentType) {
+        return build(statusCode, key, message, null, contentType);
+    }
 }


### PR DESCRIPTION
closes gravitee-io/issues#2208