### PR TITLE
feat(management): Create api from a WSDL

### DIFF
--- a/src/main/java/io/gravitee/policy/api/swagger/OperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/api/swagger/OperationVisitor.java
@@ -23,5 +23,13 @@ import java.util.Optional;
  */
 public interface OperationVisitor<D, O> {
 
+    /**
+     * Specify if the policy must be displayed on WebUI
+     * @return
+     */
+    default boolean display() {
+        return true;
+    }
+
     Optional<Policy> visit(D descriptor, O operation);
 }


### PR DESCRIPTION
Addition of a 'display' method to know if the policy checkbox has to be displayed
in the create API UI view

fix gravitee-io/issues#322